### PR TITLE
Updated code to have vertex and index buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ name = "gframe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "console_error_panic_hook",
  "console_log",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ strip = true
 
 [dependencies]
 anyhow = "1.0.98"
+bytemuck = { version = "1.23.1", features = [ "derive" ] }
 env_logger = "0.11.8"
 log = "0.4.27"
 pollster = "0.4.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,2 +1,3 @@
 pub mod app;
 pub mod state;
+pub mod vertex;

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
+use wgpu::util::DeviceExt;
 use winit::{event_loop::ActiveEventLoop, keyboard::KeyCode, window::Window};
+
+use crate::core::vertex::{INDICES, VERTICES, Vertex};
 
 pub struct State {
     surface: wgpu::Surface<'static>,
@@ -9,12 +12,17 @@ pub struct State {
     config: wgpu::SurfaceConfiguration,
     is_surface_configured: bool,
     render_pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+    num_vertices: u32,
+    num_indices: u32,
     pub window: Arc<Window>,
 }
 
 impl State {
     pub async fn new(window: Arc<Window>) -> anyhow::Result<Self> {
         let size = window.inner_size();
+        let num_vertices = VERTICES.len() as u32;
 
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             #[cfg(not(target_arch = "wasm32"))]
@@ -74,6 +82,19 @@ impl State {
             source: wgpu::ShaderSource::Wgsl(include_str!("../shader.wgsl").into()),
         });
 
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Vertex Buffer"),
+            contents: bytemuck::cast_slice(VERTICES),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Index Buffer"),
+            contents: bytemuck::cast_slice(INDICES),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+        let num_indices = INDICES.len() as u32;
+
         let render_pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Render Pipeline Layout"),
@@ -87,7 +108,7 @@ impl State {
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: Some("vs_main"),
-                buffers: &[],
+                buffers: &[Vertex::desc()],
                 compilation_options: wgpu::PipelineCompilationOptions::default(),
             },
             fragment: Some(wgpu::FragmentState {
@@ -126,6 +147,10 @@ impl State {
             config,
             is_surface_configured: false,
             render_pipeline,
+            vertex_buffer,
+            index_buffer,
+            num_vertices,
+            num_indices,
             window,
         })
     }
@@ -194,7 +219,9 @@ impl State {
             });
 
             render_pass.set_pipeline(&self.render_pipeline);
-            render_pass.draw(0..3, 0..1);
+            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -14,7 +14,6 @@ pub struct State {
     render_pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
-    num_vertices: u32,
     num_indices: u32,
     pub window: Arc<Window>,
 }
@@ -22,7 +21,6 @@ pub struct State {
 impl State {
     pub async fn new(window: Arc<Window>) -> anyhow::Result<Self> {
         let size = window.inner_size();
-        let num_vertices = VERTICES.len() as u32;
 
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             #[cfg(not(target_arch = "wasm32"))]
@@ -149,7 +147,6 @@ impl State {
             render_pipeline,
             vertex_buffer,
             index_buffer,
-            num_vertices,
             num_indices,
             window,
         })

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -1,0 +1,42 @@
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Zeroable, bytemuck::Pod)]
+pub struct Vertex {
+    position: [f32; 3],
+    colour: [f32; 3],
+}
+
+pub const VERTICES: &[Vertex] = &[
+    Vertex {
+        position: [-1.0, -1.0, 0.0],
+        colour: [1.0, 1.0, 1.0],
+    },
+    Vertex {
+        position: [-1.0, 1.0, 0.0],
+        colour: [1.0, 1.0, 1.0],
+    },
+    Vertex {
+        position: [1.0, 1.0, 0.0],
+        colour: [1.0, 1.0, 1.0],
+    },
+    Vertex {
+        position: [1.0, -1.0, 0.0],
+        colour: [1.0, 1.0, 1.0],
+    },
+];
+
+pub const INDICES: &[u16] = &[1, 0, 2, 2, 0, 3];
+
+impl Vertex {
+    const ATTRIBS: [wgpu::VertexAttribute; 2] = wgpu::vertex_attr_array![
+        0 => Float32x3, // position
+        1 => Float32x3, // colour
+    ];
+
+    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &Self::ATTRIBS,
+        }
+    }
+}

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,21 +1,24 @@
+struct VertexInput {
+  @location(0) pos: vec3<f32>,
+  @location(1) color: vec3<f32>,
+}
+
 struct VertexOutput {
   @builtin(position) clip_position: vec4<f32>,
-  @location(0) vert_pos: vec3<f32>,
+  @location(0) color: vec3<f32>,
 }
 
 @vertex
 fn vs_main(
-  @builtin(vertex_index) in_vertex_index: u32,
+  model: VertexInput,
 ) -> VertexOutput {
   var out: VertexOutput;
-  let x = f32(1 - i32(in_vertex_index)) * 0.5;
-  let y = f32(i32(in_vertex_index & 1u) * 2 - 1) * 0.5;
-  out.clip_position = vec4<f32>(x, y, 0.0, 1.0);
-  out.vert_pos = out.clip_position.xyz;
+  out.color = model.color;
+  out.clip_position = vec4<f32>(model.pos, 1.0);
   return out;
 }
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-  return vec4<f32>(0.3, 0.2, 0.1, 1.0);
+  return vec4<f32>(in.color, 1.0);
 }


### PR DESCRIPTION
continued following wgpu tutorial for adding vertex buffer and index buffer for easily setting color per vertex and index buffer for reducing duplicate vertex data.